### PR TITLE
lsコマンド3の-rコマンドを実装した

### DIFF
--- a/04.ls/ls1.rb
+++ b/04.ls/ls1.rb
@@ -1,12 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-def read_files(show_all:)
-  Dir.glob('*', show_all ? File::FNM_DOTMATCH : 0).sort
+def read_files(**)
+  Dir.glob('*').sort
 end
 
-show_all = ARGV.include?('-a')
-files = read_files(show_all:)
+reverse_mode = ARGV.include?('-r')
+files = read_files(reverse_mode:)
+files = files.reverse if reverse_mode
 
 return if files.empty?
 

--- a/04.ls/ls1.rb
+++ b/04.ls/ls1.rb
@@ -1,12 +1,12 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-def read_files(**)
+def read_files
   Dir.glob('*').sort
 end
 
 reverse_mode = ARGV.include?('-r')
-files = read_files(reverse_mode:)
+files = read_files
 files = files.reverse if reverse_mode
 
 return if files.empty?


### PR DESCRIPTION
概要（ls3）

- ls2 から -a を削除 および -r を追加
-  -r 指定時に逆順で表示（デフォルトは昇順）

変更点
-  -r 対応：一覧を昇順で取得後、-r  のときのみ逆順で表示。
- read_filesを簡素化：read_files(**) に変更し、常に Dir.glob('*').sort
-  RuboCop回避：「キーワード引数を受け取っても中では使わない」ためread_files(**)に変更。
- 表示前の反転：files = files.reverse if reverse_mode を追加。（逆順切り替え）