### PR TITLE
lsコマンド4の-lオプション作成

### DIFF
--- a/04.ls/ls1.rb
+++ b/04.ls/ls1.rb
@@ -1,20 +1,66 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'etc'
+
 def read_files
   Dir.glob('*').sort
 end
 
-reverse_mode = ARGV.include?('-r')
-files = read_files
-files = files.reverse if reverse_mode
+def main
+  files = read_files
+  return if files.empty?
 
-return if files.empty?
+  if ARGV.include?('-l')
+    l_format(files)
+  else
+    normal_format(files)
+  end
+end
+
+def permission_string(perm)
+  (perm & 4 != 0 ? 'r' : '-') +
+    (perm & 2 != 0 ? 'w' : '-') +
+    (perm & 1 != 0 ? 'x' : '-')
+end
+
+def max_filename_length(files)
+  files.map(&:length).max
+end
+
+def l_format(files)
+  total = files.map { |name| File.stat(name).blocks }.sum
+  puts "total #{total}"
+
+  max_length = max_filename_length(files)
+
+  files.each do |name|
+    stat = File.stat(name)
+    type = stat.directory? ? 'd' : '-'
+
+    digits = stat.mode.to_s(8)[-3, 3].chars.map(&:to_i)
+    perms = digits.map { |d| permission_string(d) }
+    mode = perms.join
+
+    nlink = stat.nlink.to_s.rjust(2)
+    owner = Etc.getpwuid(stat.uid).name.ljust(10)
+    group = Etc.getgrgid(stat.gid).name.ljust(6)
+    size = stat.size.to_s.rjust(4)
+    mtime = stat.mtime.strftime('%_m %e %H:%M')
+
+    puts "#{type}#{mode} #{nlink} #{owner} #{group} #{size}  #{mtime} #{name.ljust(max_length)}"
+  end
+end
 
 COLUMNS = 3
-file_lengths = files.map(&:length)
-max_length = file_lengths.max
-rows = (files.size.to_f / COLUMNS).ceil
+
+def normal_format(files)
+  max_length = max_filename_length(files)
+  rows = (files.size.to_f / COLUMNS).ceil
+
+  matrix = to_matrix(files, rows)
+  print_matrix(matrix, max_length)
+end
 
 def to_matrix(file_list, row_count)
   columns = file_list.each_slice(row_count).to_a
@@ -30,8 +76,6 @@ def to_matrix(file_list, row_count)
   columns.transpose
 end
 
-matrix = to_matrix(files, rows)
-
 def print_matrix(matrix, max_length)
   matrix.each do |row|
     row.each do |file|
@@ -41,4 +85,4 @@ def print_matrix(matrix, max_length)
   end
 end
 
-print_matrix(matrix, max_length)
+main

--- a/04.ls/ls1.rb
+++ b/04.ls/ls1.rb
@@ -40,7 +40,7 @@ def print_long_format(files)
 
     puts [
       (stat.directory? ? 'd' : '-') + perms.join,
-      stat.nlink.to_s,
+      stat.nlink.to_s.rjust(2),
       Etc.getpwuid(stat.uid).name.ljust(10),
       Etc.getgrgid(stat.gid).name.ljust(6),
       stat.size.to_s.rjust(4),

--- a/04.ls/ls1.rb
+++ b/04.ls/ls1.rb
@@ -14,7 +14,7 @@ def main
   if ARGV.include?('-l')
     print_long_format(files)
   else
-    print_normal_format(files)
+    print_column_format(files)
   end
 end
 
@@ -52,7 +52,7 @@ end
 
 COLUMNS = 3
 
-def print_normal_format(files)
+def print_column_format(files)
   max_length = max_filename_length(files)
   rows = files.size.ceildiv(COLUMNS)
 


### PR DESCRIPTION
概要（ls4）

ls3 から -r を削除 および -l を追加
-l 指定時に詳細情報を表示
メソッド分割を進めて、処理を見やすく修正

変更点

-rオプションの削除：要件外のため
l_formatメソッドの追加：詳細情報を一覧で表示するため
permission_stringメソッドの追加：パーミッションを8進数からrwx表記に変換するため
max_filename_lengthメソッドの追加：最大ファイル名の長さを取得して桁揃えをしやすくするため
normal_formatメソッドの追加：ls3ではトップレベルに置かれていた通常処理をメソッド化し、-lオプションと分けてみやすくするため
mainメソッドの追加：-lオプションの分岐をわかりやすくするため
mainを最後に呼ぶ構造に修正：プログラムを上から下に自然に読めるようにするため
