### PR TITLE
lsコマンド5（alrの合流）

### DIFF
--- a/04.ls/ls1.rb
+++ b/04.ls/ls1.rb
@@ -2,16 +2,24 @@
 # frozen_string_literal: true
 
 require 'etc'
+require 'optparse'
 
-def read_files
-  Dir.glob('*').sort
+def read_files(show_all:)
+  Dir.glob('*', show_all ? File::FNM_DOTMATCH : 0).sort
 end
 
 def main
-  files = read_files
+  options = ARGV.getopts('arl')
+
+  show_all = options['a']
+  reverse_mode = options['r']
+  long_format = options['l']
+
+  files = read_files(show_all:)
+  files = files.reverse if reverse_mode
   return if files.empty?
 
-  if ARGV.include?('-l')
+  if long_format
     print_long_format(files)
   else
     print_column_format(files)


### PR DESCRIPTION
概要
-a,-r,-lの各オプションに対応、かつ複数同時指定（-alや-arlなど）に対応しました。

変更点
- 標準ライブラリoptparseを使用し、ARGV.getopts('arl') でオプションを取得
- オプションの順不同に対応