### PR TITLE
wcコマンドを実装

### DIFF
--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+def count_text(text, name = '')
+  lines = text.count("\n")
+  words = text.split.size
+  bytes = text.bytesize
+  { name: name, lines: lines, words: words, bytes: bytes }
+end
+
+def format_record(rec, show_l:, show_w:, show_c:)
+  cols = []
+  cols << rec[:lines].to_s.rjust(8) if show_l
+  cols << rec[:words].to_s.rjust(8) if show_w
+  cols << rec[:bytes].to_s.rjust(8) if show_c
+  cols << rec[:name]
+  cols.join(' ')
+end
+
+opts = ARGV.getopts('lwc')
+any_option = opts.values.any?
+show_l = opts['l'] || !any_option
+show_w = opts['w'] || !any_option
+show_c = opts['c'] || !any_option
+
+file_names = ARGV.reject { |arg| arg.start_with?('-') }
+
+if file_names.empty?
+  text = $stdin.read
+  results = [count_text(text)]
+else
+  results = file_names.map { |fn| count_text(File.read(fn), fn) }
+
+  if file_names.size >= 2
+    totals = {
+      name: 'total',
+      lines: results.sum { |r| r[:lines] },
+      words: results.sum { |r| r[:words] },
+      bytes: results.sum { |r| r[:bytes] }
+    }
+
+    results << totals
+  end
+end
+
+results.each do |rec|
+  puts format_record(rec, show_l: show_l, show_w: show_w, show_c: show_c)
+end

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -19,10 +19,10 @@ def format_record(rec, show_l:, show_w:, show_c:)
 end
 
 opts = { 'l' => false, 'w' => false, 'c' => false }
-OptionParser.new do |o|
-  o.on('-l') { opts['l'] = true }
-  o.on('-w') { opts['w'] = true }
-  o.on('-c') { opts['c'] = true }
+OptionParser.new do |parser|
+  parser.on('-l') { opts['l'] = true }
+  parser.on('-w') { opts['w'] = true }
+  parser.on('-c') { opts['c'] = true }
 end.parse!(ARGV)
 
 if opts.values.none?
@@ -37,7 +37,7 @@ if file_names.empty?
   text = $stdin.read
   results = [count_text(text)]
 else
-  results = file_names.map { |it| count_text(File.read(it), it) }
+  results = file_names.map { |file_name| count_text(File.read(file_name), file_name) }
 
   if file_names.size >= 2
     totals = {

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -6,7 +6,7 @@ def count_text(text, name = '')
   lines = text.count("\n")
   words = text.split.size
   bytes = text.bytesize
-  { name: name, lines: lines, words: words, bytes: bytes }
+  { name:, lines:, words:, bytes: }
 end
 
 def format_record(rec, show_l:, show_w:, show_c:)
@@ -18,19 +18,26 @@ def format_record(rec, show_l:, show_w:, show_c:)
   cols.join(' ')
 end
 
-opts = ARGV.getopts('lwc')
-any_option = opts.values.any?
-show_l = opts['l'] || !any_option
-show_w = opts['w'] || !any_option
-show_c = opts['c'] || !any_option
+opts = { 'l' => false, 'w' => false, 'c' => false }
+OptionParser.new do |o|
+  o.on('-l') { opts['l'] = true }
+  o.on('-w') { opts['w'] = true }
+  o.on('-c') { opts['c'] = true }
+end.parse!(ARGV)
 
-file_names = ARGV.reject { |arg| arg.start_with?('-') }
+if opts.values.none?
+  opts['l'] = true
+  opts['w'] = true
+  opts['c'] = true
+end
+
+file_names = ARGV
 
 if file_names.empty?
   text = $stdin.read
   results = [count_text(text)]
 else
-  results = file_names.map { |fn| count_text(File.read(fn), fn) }
+  results = file_names.map { |it| count_text(File.read(it), it) }
 
   if file_names.size >= 2
     totals = {
@@ -45,5 +52,5 @@ else
 end
 
 results.each do |rec|
-  puts format_record(rec, show_l: show_l, show_w: show_w, show_c: show_c)
+  puts format_record(rec, show_l: opts['l'], show_w: opts['w'], show_c: opts['c'])
 end

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -9,26 +9,29 @@ def count_text(text, name = '')
   { name:, lines:, words:, bytes: }
 end
 
-def format_record(rec, show_l:, show_w:, show_c:)
+def format_record(rec, show:)
   cols = []
-  cols << rec[:lines].to_s.rjust(8) if show_l
-  cols << rec[:words].to_s.rjust(8) if show_w
-  cols << rec[:bytes].to_s.rjust(8) if show_c
+
+  show.each do |key, visible|
+    cols << rec[key].to_s.rjust(8) if visible
+  end
+
   cols << rec[:name]
   cols.join(' ')
 end
 
-opts = { 'l' => false, 'w' => false, 'c' => false }
+opts = { lines: false, words: false, bytes: false }
+
 OptionParser.new do |parser|
-  parser.on('-l') { opts['l'] = true }
-  parser.on('-w') { opts['w'] = true }
-  parser.on('-c') { opts['c'] = true }
+  parser.on('-l') { opts[:lines] = true }
+  parser.on('-w') { opts[:words] = true }
+  parser.on('-c') { opts[:bytes] = true }
 end.parse!(ARGV)
 
 if opts.values.none?
-  opts['l'] = true
-  opts['w'] = true
-  opts['c'] = true
+  opts[:lines] = true
+  opts[:words] = true
+  opts[:bytes] = true
 end
 
 file_names = ARGV
@@ -37,7 +40,7 @@ if file_names.empty?
   text = $stdin.read
   results = [count_text(text)]
 else
-  results = file_names.map { |it| count_text(File.read(it), it) }
+  results = file_names.map { count_text(File.read(it), it) }
 
   if file_names.size >= 2
     totals = {
@@ -52,5 +55,5 @@ else
 end
 
 results.each do |rec|
-  puts format_record(rec, show_l: opts['l'], show_w: opts['w'], show_c: opts['c'])
+  puts format_record(rec, show: opts)
 end

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -37,7 +37,7 @@ if file_names.empty?
   text = $stdin.read
   results = [count_text(text)]
 else
-  results = file_names.map { |file_name| count_text(File.read(file_name), file_name) }
+  results = file_names.map { |it| count_text(File.read(it), it) }
 
   if file_names.size >= 2
     totals = {


### PR DESCRIPTION
wcコマンド実装

・-l / -w / -c を実装（未指定は全部表示）
・単一・複数ファイルに対応、total 行を追加
・標準入力（パイプ）対応
